### PR TITLE
Generate 3d planetary ring system model

### DIFF
--- a/planetary_gearbox/README-fa.md
+++ b/planetary_gearbox/README-fa.md
@@ -1,0 +1,61 @@
+# گیربکس سیاره‌ای پارامتریک (OpenSCAD)
+
+این نمونه یک گیربکس سیاره‌ای ساده و «قابل چاپ سه‌بعدی» است. هندسه دندانه‌ها ساده‌سازی شده (اینولوت دقیق نیست) اما برای نمونه‌های آموزشی و اسباب‌بازی‌ها مناسب است.
+
+## فایل‌ها
+- `planetary_gearbox.scad`: مونتاژ و انتخاب قطعه برای خروجی STL
+- `gears.scad`: توابع تولید چرخ‌دنده خارجی و رینگی (داخلی) به‌صورت ساده
+
+## پارامترهای پیش‌فرض
+- ماژول (`m`): 1.6
+- دنده خورشیدی (`z_sun`): 12
+- دنده سیاره‌ای (`z_planet`): 18
+- دنده رینگی (`z_ring = z_sun + 2*z_planet`): 48
+- تعداد سیاره‌ها: 3
+- ضخامت دنده‌ها: 8 میلی‌متر
+
+می‌توانید این مقادیر را در ابتدای فایل `planetary_gearbox.scad` تغییر دهید.
+
+## خروجی گرفتن (STL)
+با نصب OpenSCAD می‌توانید هر قطعه را جداگانه خروجی بگیرید. مثال‌ها:
+
+```bash
+# رندر مونتاژ صرفاً برای پیش‌نمایش
+openscad -o assembly_preview.stl -D 'part="assembly"' /workspace/planetary_gearbox/planetary_gearbox.scad
+
+# چرخ‌دنده خورشیدی
+openscad -o sun.stl -D 'part="sun"' /workspace/planetary_gearbox/planetary_gearbox.scad
+
+# چرخ‌دنده سیاره‌ای
+openscad -o planet.stl -D 'part="planet"' /workspace/planetary_gearbox/planetary_gearbox.scad
+
+# چرخ‌دنده رینگی
+openscad -o ring.stl -D 'part="ring"' /workspace/planetary_gearbox/planetary_gearbox.scad
+
+# صفحه‌ی نگه‌دارنده پایین/بالا
+openscad -o carrier_bottom.stl -D 'part="carrier_bottom"' /workspace/planetary_gearbox/planetary_gearbox.scad
+openscad -o carrier_top.stl    -D 'part="carrier_top"'    /workspace/planetary_gearbox/planetary_gearbox.scad
+```
+
+اگر OpenSCAD GUI دارید، فایل `planetary_gearbox.scad` را باز کنید و مقدار `part` را روی قطعه‌ی مدنظر بگذارید و سپس Export STL بگیرید.
+
+## نکات چاپ سه‌بعدی (FDM)
+- **نازل 0.4 / لایه 0.2**: کیفیت مناسب/زمان معقول
+- **دیوارها**: 3–4 پیرامید برای رینگی، 2–3 برای دنده‌ها
+- **پرکنندگی**: 30–60٪ برای رینگی و صفحات؛ 20–40٪ برای دنده‌ها
+- **کلیرنس XY** (`clearance_xy`): پیش‌فرض 0.25 میلی‌متر؛ اگر لق یا سفت بود، کمی کم/زیاد کنید
+- **جهت قرارگیری**: دنده‌ها را خوابانده چاپ کنید؛ رینگی به صورت لیوانی رو به بالا
+- **جنس**: PLA/PLA+ برای آموزش؛ PETG/ABS برای دوام بیشتر
+
+## سرهم‌بندی
+1. رینگی را کف میز بگذارید.
+2. صفحه‌ی پایین (`carrier_bottom`) را داخل لبه‌ی رینگی قرار دهید.
+3. دنده خورشیدی را وسط بگذارید (سوراخ مرکزی برای شفت).
+4. دنده‌های سیاره‌ای را با پین‌های 5 میلی‌متری روی شعاع مشخص نصب کنید.
+5. صفحه‌ی بالا را بگذارید و با پیچ‌های M3 روی دایره‌ی پیچ، محکم کنید.
+
+> این مدل برای بارهای سبک طراحی شده است. برای انتقال قدرت واقعی، از دندانه‌های اینولوت دقیق و یاتاقان/بوش مناسب استفاده کنید.
+
+## شخصی‌سازی سریع
+- نسبت تبدیل: `z_ring - z_sun : z_sun` (برای این تنظیم ≈ 3:1)
+- تنظیم خلاصی: `tooth_fraction` را روی 0.40–0.48 و `backlash_angle_extra` را 0–1.0 درجه تغییر دهید.

--- a/planetary_gearbox/gears.scad
+++ b/planetary_gearbox/gears.scad
@@ -1,0 +1,101 @@
+// Simple parametric gear primitives for printable demo planetary gearboxes
+// Note: This is a simplified tooth geometry (not true involute). Good for demo/toy loads.
+// Units: millimeters
+
+// =====================
+// Utility
+// =====================
+function deg2rad(a) = a * PI / 180;
+function rad2deg(a) = a * 180 / PI;
+
+// Point on a circle for angle in degrees
+function circle_pt(r, a_deg) = [ r * cos(deg2rad(a_deg)), r * sin(deg2rad(a_deg)) ];
+
+// Generate a wedge-shaped ring sector polygon between radii [r_in, r_out] and +/- ang/2
+// segs controls discretization of the arcs
+module ring_wedge(r_in, r_out, ang_deg, segs=6) {
+	ang_half = ang_deg/2;
+	outer_pts = [ for (i=[0:segs]) circle_pt(r_out, -ang_half + i*(ang_deg/segs)) ];
+	inner_pts = [ for (i=[0:segs]) circle_pt(r_in, ang_half - i*(ang_deg/segs)) ];
+	polygon(points = concat(outer_pts, inner_pts));
+}
+
+// =====================
+// External gear (simplified)
+// =====================
+// Parameters:
+// - z: number of teeth
+// - m: module (mm)
+// - thickness: extrusion thickness (mm)
+// - tooth_fraction: fraction of pitch allocated to tooth thickness at pitch circle (0.0-1.0). 0.45 recommended for backlash
+// - addendum, dedendum: standard gear proportions
+// - backlash_angle_extra: extra angular clearance added to each tooth space (deg)
+// - bore_diameter: center bore diameter (mm)
+module external_gear_3d(z=20, m=1.6, thickness=8, tooth_fraction=0.45, addendum_mul=1.0, dedendum_mul=1.25, backlash_angle_extra=0.0, bore_diameter=5.0, fn_outer=120) {
+	pitch_d = m * z;
+	pitch_r = pitch_d / 2;
+	addendum = addendum_mul * m;
+	dedendum = dedendum_mul * m;
+	outer_r = pitch_r + addendum;
+	root_r = max(0.1, pitch_r - dedendum);
+	pitch_ang = 360 / z;
+	tooth_ang = pitch_ang * tooth_fraction;
+	space_ang = pitch_ang - tooth_ang + backlash_angle_extra;
+	$fn = fn_outer;
+
+	linear_extrude(height=thickness) difference() {
+		circle(r=outer_r);
+		// Cut tooth spaces as wedges
+		for (i=[0:z-1]) rotate(i*pitch_ang)
+			ring_wedge(r_in=root_r, r_out=outer_r+0.2, ang_deg=space_ang, segs=6);
+		// Center bore
+		circle(r=bore_diameter/2);
+	}
+}
+
+// =====================
+// Internal gear (simplified)
+// =====================
+// Creates a ring gear body with inward-pointing simplified teeth
+// Parameters:
+// - z: number of internal teeth
+// - m: module (mm)
+// - thickness: extrusion thickness (mm)
+// - tooth_fraction: see external
+// - ring_wall: extra wall thickness outside the tooth root (mm)
+// - backlash_angle_extra: extra angular clearance added to each tooth space (deg)
+// - bore_diameter: through bore (optional)
+module internal_ring_gear_3d(z=50, m=1.6, thickness=12, tooth_fraction=0.45, ring_wall=3.0, addendum_mul=1.0, dedendum_mul=1.25, backlash_angle_extra=0.0, bore_diameter=0, fn_outer=160) {
+	pitch_d = m * z;
+	pitch_r = pitch_d / 2;
+	addendum = addendum_mul * m;   // tooth tip towards center
+	dedendum = dedendum_mul * m;   // towards outside
+	inner_tip_r = max(0.1, pitch_r - addendum); // smallest radius (tooth tips)
+	inner_root_r = pitch_r + dedendum;          // largest inner radius (tooth valleys)
+	ring_outer_r = inner_root_r + ring_wall;    // body outside the teeth
+	pitch_ang = 360 / z;
+	tooth_ang = pitch_ang * tooth_fraction;
+	space_ang = pitch_ang - tooth_ang + backlash_angle_extra; // space cuts between internal teeth
+	$fn = fn_outer;
+
+	linear_extrude(height=thickness) difference() {
+		// Solid ring body
+		circle(r=ring_outer_r);
+		// Carve inner bore to the tooth valleys
+		circle(r=inner_root_r);
+		// Carve spaces between internal teeth as wedges protruding inward
+		for (i=[0:z-1]) rotate(i*pitch_ang)
+			ring_wedge(r_in=inner_tip_r-0.2, r_out=inner_root_r+0.2, ang_deg=space_ang, segs=6);
+		// Optional through bore
+		if (bore_diameter > 0)
+			circle(r=bore_diameter/2);
+	}
+}
+
+// =====================
+// Helper: circular array placement
+// =====================
+module around(radius, count) {
+	for (i=[0:count-1])
+		rotate([0,0,i*(360/count)]) translate([radius,0,0]) children();
+}

--- a/planetary_gearbox/planetary_gearbox.scad
+++ b/planetary_gearbox/planetary_gearbox.scad
@@ -1,0 +1,158 @@
+// Parametric printable planetary gearbox (simplified tooth geometry)
+// Author: AI assistant
+// Units: millimeters
+
+include <gears.scad>
+
+// =====================
+// Global parameters (tweak as needed)
+// =====================
+part = "assembly"; // options: assembly | sun | planet | ring | carrier_top | carrier_bottom | spacer
+
+// Gear train
+m = 1.6;                 // module (mm)
+z_sun = 12;              // sun gear teeth
+z_planet = 18;           // planet gear teeth
+n_planets = 3;           // number of planets (3 or 4 typical)
+wall = 3.0;              // ring wall thickness (outside tooth root)
+tooth_fraction = 0.45;   // 0.40..0.48 recommended for FDM backlash
+backlash_angle_extra = 0.5; // extra deg in tooth spaces to loosen mesh
+
+// Thicknesses
+gear_thickness = 8;      // sun/planet thickness
+ring_thickness = 14;     // ring body thickness (can be taller to form a cup)
+carrier_thickness = 4;   // each carrier plate
+spacer_thickness = 2;    // optional spacer/washer for top/bottom
+
+// Holes and shafts
+center_bore_d = 8.0;     // center shaft bore in carriers & sun
+planet_pin_d = 5.0;      // planet pin diameter (print pins or use M5 smooth rod)
+bolt_hole_d = 3.2;       // bolt holes in carriers (for M3)
+bolt_circle_d = 40;      // bolt circle diameter on carriers
+
+// Body & clearances
+clearance_xy = 0.25;     // extra radial clearance for bores
+ring_body_lip = 2.0;     // lip to seat a cover/carrier
+
+// Derived
+z_ring = z_sun + 2*z_planet;            // relationship for coaxial planetary
+pitch_r_sun = (m*z_sun)/2;
+pitch_r_planet = (m*z_planet)/2;
+pitch_r_ring = (m*z_ring)/2;
+planet_center_r = pitch_r_sun + pitch_r_planet; // planet orbit radius
+
+// =====================
+// Parts
+// =====================
+module part_sun() {
+	external_gear_3d(
+		z=z_sun,
+		m=m,
+		thickness=gear_thickness,
+		tooth_fraction=tooth_fraction,
+		addendum_mul=1.0,
+		dedendum_mul=1.25,
+		backlash_angle_extra=backlash_angle_extra,
+		bore_diameter=center_bore_d + clearance_xy
+	);
+}
+
+module part_planet() {
+	external_gear_3d(
+		z=z_planet,
+		m=m,
+		thickness=gear_thickness,
+		tooth_fraction=tooth_fraction,
+		addendum_mul=1.0,
+		dedendum_mul=1.25,
+		backlash_angle_extra=backlash_angle_extra,
+		bore_diameter=planet_pin_d + clearance_xy
+	);
+}
+
+module part_ring() {
+	internal_ring_gear_3d(
+		z=z_ring,
+		m=m,
+		thickness=ring_thickness,
+		tooth_fraction=tooth_fraction,
+		ring_wall=wall,
+		addendum_mul=1.0,
+		dedendum_mul=1.25,
+		backlash_angle_extra=backlash_angle_extra,
+		bore_diameter=0
+	);
+}
+
+// Carrier plates (top/bottom)
+// - Central bore for shaft
+// - Planet pin holes on radius = planet_center_r
+// - Bolt circle for closing the sandwich
+module part_carrier(is_top=true) {
+	d_hub = max(center_bore_d + 6, 2*(pitch_r_sun*0.6));
+	plate_r = max(pitch_r_ring + wall + 4, bolt_circle_d/2 + 6);
+	linear_extrude(height=carrier_thickness) difference() {
+		// outer profile with a small lip recess for the ring
+		union() {
+			circle(r=plate_r);
+			if (is_top) translate([0,0,0]) circle(r=plate_r); // placeholder to keep symmetric
+		}
+		// center bore
+		circle(r=(center_bore_d + clearance_xy)/2);
+		// planet pin holes
+		for (i=[0:n_planets-1]) rotate(i*360/n_planets)
+			translate([planet_center_r,0,0]) circle(r=(planet_pin_d + clearance_xy)/2);
+		// bolt holes
+		for (i=[0:3]) rotate(i*90)
+			translate([bolt_circle_d/2,0,0]) circle(r=bolt_hole_d/2);
+	}
+}
+
+module part_spacer(diameter=10) {
+	linear_extrude(height=spacer_thickness) difference() {
+		circle(r=diameter/2);
+		circle(r=(diameter/2) - 1.0);
+	}
+}
+
+// =====================
+// Assembly (visualization only)
+// =====================
+module assembly_view() {
+	// Ring as base cup
+	color([0.85,0.85,0.9]) translate([0,0,0]) part_ring();
+	// Bottom carrier
+	color([0.8,0.6,0.4]) translate([0,0,0.1]) part_carrier(is_top=false);
+	// Sun at center
+	color([0.9,0.2,0.2]) translate([0,0,carrier_thickness + 0.2]) part_sun();
+	// Planets
+	for (i=[0:n_planets-1])
+		color([0.2,0.6,0.9])
+			translate([0,0,carrier_thickness + 0.2])
+			rotate([0,0,i*(360/n_planets)])
+			translate([planet_center_r,0,0])
+			part_planet();
+	// Top carrier
+	color([0.8,0.6,0.4]) translate([0,0,carrier_thickness + gear_thickness + 0.4]) part_carrier(is_top=true);
+}
+
+// =====================
+// Selector
+// =====================
+if (part == "sun") part_sun();
+else if (part == "planet") part_planet();
+else if (part == "ring") part_ring();
+else if (part == "carrier_top") part_carrier(is_top=true);
+else if (part == "carrier_bottom") part_carrier(is_top=false);
+else if (part == "spacer") part_spacer(diameter=10);
+else assembly_view();
+
+// Helpful echoes
+$echo_parameters = [
+	["module", m],
+	["z_sun", z_sun],
+	["z_planet", z_planet],
+	["z_ring", z_ring],
+	["n_planets", n_planets],
+	["planet_center_r", planet_center_r]
+];


### PR DESCRIPTION
Add parametric OpenSCAD files for a 3D printable planetary gearbox.

---
<a href="https://cursor.com/background-agent?bcId=bc-af99d630-6857-4c8e-a451-6d713a5c5767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af99d630-6857-4c8e-a451-6d713a5c5767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

